### PR TITLE
Added Service Widget - Refactored ServiceController 

### DIFF
--- a/usr/plugins/devel/caddy/src/etc/inc/plugins.inc.d/caddy.inc
+++ b/usr/plugins/devel/caddy/src/etc/inc/plugins.inc.d/caddy.inc
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (C) 2023 Cedrik Pischem
+ * Copyright (C) 2017 EURO-LOG AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+function caddy_services()
+{
+    global $config;
+
+    $services = array();
+
+    if (isset($config['Pischem']['caddy']['general']['enabled']) &&
+        $config['Pischem']['caddy']['general']['enabled'] == 1) {
+        $services[] = array(
+            'description' => gettext('Caddy Web Server'),
+            'configd' => array(
+                'restart' => array('caddy restart'),
+                'start' => array('caddy start'),
+                'stop' => array('caddy stop'),
+            ),
+            'name' => 'caddy',
+            'pidfile' => '/var/run/caddy.pid'
+        );
+    }
+
+    return $services;
+}
+
+function caddy_xmlrpc_sync()
+{
+    $result = array();
+
+    $result[] = array(
+        'description' => gettext('Caddy Web Server'),
+        'section' => 'Pischem.caddy',
+        'id' => 'caddy',
+        'services' => ["caddy"],
+    );
+
+    return $result;
+}

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/Api/ServiceController.php
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/Api/ServiceController.php
@@ -41,30 +41,6 @@ class ServiceController extends ApiMutableServiceControllerBase
     protected static $internalServiceEnabled = 'general.enabled';
     protected static $internalServiceName = 'caddy';
 
-    private function reloadTemplate()
-    {
-        $backend = new Backend();
-        $backend->configdRun("template reload " . static::$internalServiceTemplate);
-    }
-
-    public function startAction()
-    {
-        $this->reloadTemplate();
-        return parent::startAction();
-    }
-
-    public function stopAction()
-    {
-        $this->reloadTemplate();
-        return parent::stopAction();
-    }
-
-    public function restartAction()
-    {
-        $this->reloadTemplate();
-        return parent::restartAction();
-    }
-
     protected function reconfigureForceRestart()
     {
         return 0;

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/Api/ServiceController.php
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/Api/ServiceController.php
@@ -3,7 +3,7 @@
 /**
  *    Copyright (C) 2015 Deciso B.V.
  *    Copyright (C) 2023 Cedrik Pischem
- * 
+ *
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -41,90 +41,32 @@ class ServiceController extends ApiMutableServiceControllerBase
     protected static $internalServiceEnabled = 'general.enabled';
     protected static $internalServiceName = 'caddy';
 
-    /**
-     * Reload Caddy configuration
-     */
-    public function restartAction()
+    private function reloadTemplate()
     {
-        $status = "failed";
-        if ($this->request->isPost()) {
-            $backend = new Backend();
-
-            // Reload the template
-            $templateResult = trim($backend->configdRun("template reload Pischem/Caddy"));
-            if ($templateResult !== "OK") {
-                return array("status" => "failed", "message" => "Failed to reload template");
-            }
-
-            // Restart the service
-            $bckresult = trim($backend->configdRun('caddy restart'));
-            if ($bckresult == "OK") {
-                $status = "ok";
-            }
-        }
-        return array("status" => $status, "message" => "Reloading Caddy configuration");
+        $backend = new Backend();
+        $backend->configdRun("template reload " . static::$internalServiceTemplate);
     }
 
-    /**
-     * Stop Caddy service
-     */
-    public function stopAction()
-    {
-        $status = "failed";
-        if ($this->request->isPost()) {
-            $backend = new Backend();
-
-            // Reload the template before stopping the service
-            $templateResult = trim($backend->configdRun("template reload Pischem/Caddy"));
-            if ($templateResult !== "OK") {
-                return array("status" => "failed", "message" => "Failed to reload template");
-            }
-
-            // Stop the service
-            $bckresult = trim($backend->configdRun('caddy stop'));
-            if ($bckresult == "OK") {
-                $status = "ok";
-            }
-        }
-        return array("status" => $status, "message" => "Stopping Caddy service");
-    }
-
-    /**
-     * Start Caddy service
-     */
     public function startAction()
     {
-        $status = "failed";
-        if ($this->request->isPost()) {
-            $backend = new Backend();
-
-            // Reload the template
-            $templateResult = trim($backend->configdRun("template reload Pischem/Caddy"));
-            if ($templateResult !== "OK") {
-                return array("status" => "failed", "message" => "Failed to reload template");
-            }
-
-            // Start the service
-            $bckresult = trim($backend->configdRun('caddy start'));
-            if ($bckresult == "OK") {
-                $status = "ok";
-            }
-        }
-        return array("status" => $status, "message" => "Starting Caddy service");
+        $this->reloadTemplate();
+        return parent::startAction();
     }
-    
-    /**
-    * Test Action for Caddy service
-    */
-        public function testAction()
+
+    public function stopAction()
     {
-        if ($this->request->isPost()) {
-            $backend = new Backend();
-            $response = json_decode(trim($backend->configdRun("caddy test")), true);
-            return $response;
-        } else {
-            return array("status" => "failed");
-        }
+        $this->reloadTemplate();
+        return parent::stopAction();
+    }
+
+    public function restartAction()
+    {
+        $this->reloadTemplate();
+        return parent::restartAction();
+    }
+
+    protected function reconfigureForceRestart()
+    {
+        return 0;
     }
 }
-

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/general.volt
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/general.volt
@@ -24,7 +24,6 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-
 <div style="background-color: white; padding: 10px; border: 1px solid #ddd;">
     <div class="content">
         <h1>Caddy General Settings</h1>
@@ -33,10 +32,17 @@
 </div>
 
 <div style="margin-top: 20px; width: 100%; background-color: white; padding: 5px; border: 1px solid #ddd;">
-    <button id="applyGeneralAct" class="btn btn-primary" type="button" style="margin-left: 4px;"><b>Apply</b></button>
+    <!-- Reconfigure Button with Pre-Action -->
+    <button class="btn btn-primary" id="reconfigureAct"
+            data-endpoint="/api/caddy/service/reconfigure"
+            data-label="{{ lang._('Apply') }}"
+            data-error-title="{{ lang._('Error reconfiguring Caddy') }}"
+            type="button"
+    ><b>Reconfigure</b></button>
 </div>
 
 <script type="text/javascript">
+
     $(document).ready(function() {
         var data_get_map = {'frm_GeneralSettings':"/api/caddy/General/get"};
         mapDataToFormUI(data_get_map).done(function(data){
@@ -63,48 +69,27 @@
 
             // Refresh selectpicker for these dropdowns
             $('.selectpicker').selectpicker('refresh');
-        });
 
-        // Link save button to API set action
-        $("#applyGeneralAct").click(function(){
-            saveFormToEndpoint(url="/api/caddy/general/set", formid='frm_GeneralSettings', callback_ok=function(){
-                // Fetch the updated general settings
-                fetch('/api/caddy/General/get')
-                    .then(response => response.json())
-                    .then(data => {
-                        // Check the updated status of Caddy
-                        if (data.caddy.general.enabled === "1") {
-                            // Caddy enabled, start the service
-                            $.ajax({
-                                url: "/api/caddy/service/restart",
-                                method: "POST",
-                                success: function(data) {
-                                    console.log("Caddy service started successfully:", data);
-                                    // Reload the page after the operation completes
-                                    location.reload();
-                                },
-                                error: function(xhr, status, error) {
-                                    console.error("Failed to start Caddy service:", error);
-                                }
-                            });
-                        } else {
-                            // Caddy disabled, stop the service
-                            $.ajax({
-                                url: "/api/caddy/service/stop",
-                                method: "POST",
-                                success: function(data) {
-                                    console.log("Caddy service stopped successfully:", data);
-                                    // Reload the page after the operation completes
-                                    location.reload();
-                                },
-                                error: function(xhr, status, error) {
-                                    console.error("Failed to stop Caddy service:", error);
-                                }
-                            });
-                        }
-                    })
-                    .catch(error => console.error('Error fetching updated Caddy general settings:', error));
+            // Initialize the Reconfigure button with a pre-action
+            $("#reconfigureAct").SimpleActionButton({
+                onPreAction: function() {
+                    const dfd = $.Deferred();
+
+                    // Save the form data
+                    saveFormToEndpoint("/api/caddy/general/set", 'frm_GeneralSettings', function(){
+                        dfd.resolve();  // Resolve the Deferred object after successful save
+                    }, function() {
+                        dfd.reject();   // Reject the Deferred object on failure
+                    });
+
+                    return dfd.promise();  // Return the promise
+                },
+                onAction: function(data, status) {
+                    // This function is called after the pre-action is successful
+                    console.log("Reconfigure action initiated");
+                }
             });
         });
     });
+
 </script>

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/general.volt
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/general.volt
@@ -38,11 +38,10 @@
             data-label="{{ lang._('Apply') }}"
             data-error-title="{{ lang._('Error reconfiguring Caddy') }}"
             type="button"
-    ><b>Reconfigure</b></button>
+    ><b>Apply</b></button>
 </div>
 
 <script type="text/javascript">
-
     $(document).ready(function() {
         var data_get_map = {'frm_GeneralSettings':"/api/caddy/General/get"};
         mapDataToFormUI(data_get_map).done(function(data){
@@ -85,11 +84,19 @@
                     return dfd.promise();  // Return the promise
                 },
                 onAction: function(data, status) {
-                    // This function is called after the pre-action is successful
-                    console.log("Reconfigure action initiated");
+                    if (status === "success" && data && data['status'].toLowerCase() === 'ok') {
+                    // Reload the page if the action was successful
+                        location.reload();
+                    } else {
+                    // Handle any errors or unsuccessful actions
+                        console.error("Action was not successful or an error occurred:", data);
+                    }
                 }
             });
+
+            // Initialize the service control UI for 'caddy'
+            updateServiceControlUI('caddy');
+
         });
     });
-
 </script>

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/reverse_proxy.volt
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/reverse_proxy.volt
@@ -62,7 +62,13 @@
 </div>
 
 <div style="margin-top: 20px; width: 100%; background-color: white; padding: 5px; border: 1px solid #ddd;">
-    <button id="globalApplyButton" class="btn btn-primary" type="button" style="margin-left: 4px;">Apply</button>
+    <!-- Reconfigure Button with Pre-Action -->
+    <button class="btn btn-primary" id="reconfigureAct"
+            data-endpoint="/api/caddy/service/reconfigure"
+            data-label="{{ lang._('Apply') }}"
+            data-error-title="{{ lang._('Error reconfiguring Caddy') }}"
+            type="button"
+    ><b>Reconfigure</b></button>
 </div>
 
 <script type="text/javascript">
@@ -184,40 +190,7 @@
             window.location.href = '/ui/caddy/reverse_proxy_form';
         });
 
-        // Event listener for the Apply button
-        document.getElementById('globalApplyButton').addEventListener('click', function() {
-            // Fetch the general settings first
-            fetch('/api/caddy/General/get')
-                .then(response => response.json())
-                .then(data => {
-                    // Check if Caddy is enabled
-                    if (data.caddy.general.enabled === "1") {
-                        // Trigger the restart service action if enabled
-                        $.ajax({
-                            url: "/api/caddy/service/restart",
-                            method: "POST",
-                            success: function(data) {
-                                console.log("Service action successful:", data);
-                                // Optionally, display a success message or handle the response further
-                            },
-                            error: function(xhr, status, error) {
-                                console.error("Service action failed:", error);
-                                // Optionally, handle the error, display a message, etc.
-                            }
-                        }).done(function() {
-                            // Reload the page after the operation completes
-                            location.reload();
-                        });
-                    } else {
-                        console.log("Caddy service is not enabled. Skipping restart.");
-                        // Optionally, display a message indicating that the service won't be restarted
-                    }
-                })
-                .catch(error => {
-                    console.error('Error fetching Caddy general settings:', error);
-                    // Optionally, handle the error, display a message, etc.
-                });
-        });
-
+        // Initialize the Reconfigure button
+        $("#reconfigureAct").SimpleActionButton();
     });
 </script>

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/reverse_proxy.volt
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/reverse_proxy.volt
@@ -68,7 +68,7 @@
             data-label="{{ lang._('Apply') }}"
             data-error-title="{{ lang._('Error reconfiguring Caddy') }}"
             type="button"
-    ><b>Reconfigure</b></button>
+    ><b>Apply</b></button>
 </div>
 
 <script type="text/javascript">
@@ -190,7 +190,8 @@
             window.location.href = '/ui/caddy/reverse_proxy_form';
         });
 
-        // Initialize the Reconfigure button
+        // Initialize the Apply button using SimpleActionButton
         $("#reconfigureAct").SimpleActionButton();
+
     });
 </script>

--- a/usr/plugins/devel/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
+++ b/usr/plugins/devel/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
@@ -16,9 +16,8 @@ parameters:
 type:script_output
 message:Reloading Caddy configuration
 
-[test]
-command:/usr/local/opnsense/scripts/Pischem/Caddy/caddy_control.py test
+[status]
+command:/usr/local/sbin/pluginctl -s caddy status
 parameters:
 type:script_output
-message:Testing Caddy service
-
+message:Request Caddy status


### PR DESCRIPTION
- Added Service Widget 
- Refactored ServiceController
- Removed the TestAction and implemented the StatusAction which uses the pluginctl to receive the status of caddy via the pid file.
- Added ServiceControllerUI to the General.volt page
- Implemented the ReconfigureAct on the apply buttons instead of using start/stop/restart API calls.