### PR TITLE
Add backend path prepend feature to handler configuration

### DIFF
--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/Api/ReverseProxyController.php
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/Api/ReverseProxyController.php
@@ -109,7 +109,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     public function searchHandleAction()
     {
-        return $this->searchBase("reverseproxy.handle", ['enabled', 'reverse', 'subdomain', 'HandleType', 'HandlePath', 'ToDomain', 'ToPort', 'HttpTls', 'HttpTlsTrustedCaCerts', 'HttpTlsServerName', 'HttpNtlm', 'Description']);
+        return $this->searchBase("reverseproxy.handle", ['enabled', 'reverse', 'subdomain', 'HandleType', 'HandlePath', 'ToDomain', 'ToPort', 'ToPath', 'HttpTls', 'HttpTlsTrustedCaCerts', 'HttpTlsServerName', 'HttpNtlm', 'Description']);
     }
 
     public function setHandleAction($uuid)

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/forms/dialogHandle.xml
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/controllers/Pischem/Caddy/forms/dialogHandle.xml
@@ -48,6 +48,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.ToPath</id>
+        <label>Backend Path</label>
+        <type>text</type>
+        <help><![CDATA[Enter a path prefix like '/guacamole' that should be prepended to the backend request because the application demands it.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>handle.HttpTls</id>
         <label>TLS</label>
         <type>checkbox</type>

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/models/Pischem/Caddy/Caddy.xml
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/models/Pischem/Caddy/Caddy.xml
@@ -245,6 +245,10 @@
                     <EnableWellKnown>Y</EnableWellKnown>
                     <EnableRanges>N</EnableRanges>
                 </ToPort>
+                <ToPath type="TextField">
+                    <Mask>/^(\/.*)?$/u</Mask>
+                    <ValidationMessage>Please enter a valid 'Backend Path' that starts with '/'.</ValidationMessage>
+                </ToPath>
                 <HttpTls type="BooleanField">
                     <Default>0</Default>
                 </HttpTls>

--- a/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/reverse_proxy.volt
+++ b/usr/plugins/devel/caddy/src/opnsense/mvc/app/views/Pischem/Caddy/reverse_proxy.volt
@@ -182,6 +182,7 @@
                             <th data-column-id="HandlePath" data-type="string">Handle Path</th>
                             <th data-column-id="ToDomain" data-type="string">Backend Domain</th>
                             <th data-column-id="ToPort" data-type="string">Backend Port</th>
+                            <th data-column-id="ToPath" data-type="string">Backend Path</th>
                             <th data-column-id="HttpTls" data-type="boolean" data-formatter="boolean" data-visible="false">TLS</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">TLS CA</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">TLS Server Name</th>

--- a/usr/plugins/devel/caddy/src/opnsense/service/templates/Pischem/Caddy/Caddyfile
+++ b/usr/plugins/devel/caddy/src/opnsense/service/templates/Pischem/Caddy/Caddyfile
@@ -158,6 +158,9 @@
 
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
+        {% if handle.ToPath|default("") != "" %}
+        rewrite * {{ handle.ToPath }}{uri}
+        {% endif %}
         reverse_proxy {{ handle.ToDomain }}{% if handle.ToPort %}:{{ handle.ToPort }}{% endif %} {
             {% if handle.HttpTls|default("0") == "1" %}
             {% if handle.HttpNtlm|default("0") == "1" %}


### PR DESCRIPTION
Hi Cedrik,

I was able to solve the "Guacamole problem" by adding a single field to the handler configuration dialog and Caddyfile template. I guess you'll like it, because it's rather unobtrusive, hidden behind "advanced settings" anyway, and does not add bloat to the plugin for rare edge cases.

The corresponding Caddy community dicussion that lead me to this solution can be found here:
https://caddy.community/t/reverse-proxy-to-a-upstream-server-with-a-path-or-subfolder/15335

Combined with the existing handle_path mechanism that gives you rather flexible rewrite options.

Kind regards,
Patrick