### PR TITLE
Omit vultr from DNS-Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - ACME DNS-01 challenge with configuration (requires supported DNS Provider)
 - Dynamic DNS (DynDns) with configuration (requires supported DNS Provider)
 - Supported DNS Providers in GUI:
-- ```cloudflare, duckdns, digitalocean, dnspod, hetzner, godaddy, gandi, vultr, ionos, desec, porkbun, route53```
+- ```cloudflare, duckdns, digitalocean, dnspod, hetzner, godaddy, gandi, ionos, desec, porkbun, route53```
 - Use custom certificates from OPNsense certificate store
 - Normal domains, wildcard domains and subdomains
 - Access Lists to restrict access based on static networks


### PR DESCRIPTION
Remove vultr since it is not compatible right now with the build when combined with:

github.com/caddy-dns/netcup \
github.com/caddy-dns/desec \
github.com/caddy-dns/porkbun \
github.com/caddy-dns/netlify \
github.com/caddy-dns/namesilo

Since desec has been especially requested in a past issue, the priority is on providing that.
https://github.com/Monviech/os-caddy-plugin/issues/75

Compare Build Issue to:
https://github.com/Monviech/os-caddy-plugin/issues/102

This is for preparation to include the plugin into the OPNsense.